### PR TITLE
Update Xcode framework search paths

### DIFF
--- a/ios/RNReactNativeZoomSdk.xcodeproj/project.pbxproj
+++ b/ios/RNReactNativeZoomSdk.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/Frameworks",
 					"$(SRCROOT)/../../../ios",
 					"$(SRCROOT)/../../../iOS",
 				);
@@ -208,6 +209,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../ios/Frameworks",
 					"$(SRCROOT)/../../../ios",
 					"$(SRCROOT)/../../../iOS",
 				);


### PR DESCRIPTION
In our project, we have frameworks stored in `ios/Frameworks` folder, but if I put `ZoomAuthenticationHybrid.framework` file into it, Xcode project doesn't compile, because it doesn't find it. I understand that documentation says "locate ZoomAuthenticationHybrid.framework, copy it to your ios/ directory...", but I think it would be convenient to have an option to put it also into Frameworks.

A better solution would be to have it optionally set by the user's project settings, but I didn't find how to do that.