### PR TITLE
Allow to customize frame, feedback and oval colors

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeZoomSdkModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeZoomSdkModule.java
@@ -117,6 +117,13 @@ public class RNReactNativeZoomSdkModule extends ReactContextBaseJavaModule {
         currentCustomization.showRetryScreen= opts.getBoolean("showRetryScreen");
         currentCustomization.enableLowLightMode = opts.getBoolean("enableLowLightMode");
 
+        if (opts.hasKey("mainBackgroundColors")) {
+          ReadableArray mainBackgroundColors = opts.getArray("mainBackgroundColors");
+          // This attribute contains array of 2 colors for gradient, but it seems like Java API
+          // doesn't allow to set gradient, so we take just the first.
+          currentCustomization.mainBackgroundColor = Color.parseColor(mainBackgroundColors.getString(0));
+        }
+
         addFrameCustomizations(currentCustomization, opts);
         addFeedbackCustomizations(currentCustomization, opts);
         addOvalCustomizations(currentCustomization, opts);
@@ -166,7 +173,6 @@ public class RNReactNativeZoomSdkModule extends ReactContextBaseJavaModule {
 
       if (feedbackCustomizationOptions.hasKey("backgroundColor")) {
         ReadableArray backgroundColors = feedbackCustomizationOptions.getArray("backgroundColor");
-
         // This attribute contains array of 2 colors for gradient, but it seems like Java API
         // doesn't allow to set gradient, so we take just the first.
         String backgroundColor = backgroundColors.getString(0);

--- a/defaults.js
+++ b/defaults.js
@@ -17,6 +17,8 @@ GJD4GIVvR+j12gXAaftj3ahfYxioBH7F7HQxzmWkwDyn3bqU54eaiB7f0ftsPpWM
 ceUaqkL2DZUvgN0efEJjnWy5y1/Gkq5GGWCROI9XG/SwXJ30BbVUehTbVcD70+ZF
 8QIDAQAB
 -----END PUBLIC KEY-----`,
+  feedbackCustomization: {},
+  ovalCustomization: {},
   // mainBackgroundColors: [UIColor]
   // mainForegroundColor: UIColor
   // buttonTextNormalColor: UIColor

--- a/ios/ZoomAuth.swift
+++ b/ios/ZoomAuth.swift
@@ -257,6 +257,11 @@ class ZoomAuth:  RCTViewManager, ZoomVerificationDelegate {
     currentCustomization.showUserLockedScreen = (options["showUserLockedScreen"] as? Bool)!
     currentCustomization.showRetryScreen = (options["showRetryScreen"] as? Bool)!
     currentCustomization.enableLowLightMode = (options["enableLowLightMode"] as? Bool)!
+    
+    let mainBackgroundColors = options["mainBackgroundColors"] != nil ? options["mainBackgroundColors"] as! Array<String> : []
+    if !mainBackgroundColors.isEmpty {
+      currentCustomization.mainBackgroundColors = [convertToUIColor(hex: mainBackgroundColors[0]), convertToUIColor(hex: mainBackgroundColors[1])]
+    }
 
     addFrameCustomizations(currentCustomization: currentCustomization, options: options)
     addFeedbackCustomizations(currentCustomization: currentCustomization, options: options)


### PR DESCRIPTION
This allows adding customization attributes as objects in `opts` JSON to be counterparts for SDK customization objects (frame, feedback, oval). I just added feedback and oval for now, but I can refactor the frame in the same way later.

Example of config:
```js
{ 
  ...
  backgroundColor: '#D50032',
  borderColor: '#FFFFFF',
  feedbackCustomization: {
    backgroundColor: ['#D3284C', '#F05A78'],
  },
  ovalCustomization: {
    progressColor1: '#FA551E',
    progressColor2: '#D3284C',
  },
  ...
}
```

What do you think?